### PR TITLE
Fix WHERE condition space-time production SQL statement error

### DIFF
--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -223,6 +223,8 @@ class Pdox
                 $_where[] = $type . $column . '=' . $this->escape($data);
             }
             $where = implode(' ' . $andOr . ' ', $_where);
+        } else if (is_null($where) || empty($where)) {
+            $where = null;
         } else {
             if (is_array($op)) {
                 $x = explode('?', $where);


### PR DESCRIPTION
Bug reproduction：
```
function init($date = ''){
    $condition = [];
    if( $date != '' ){
            $condition = ['createtime'=>strtotime($data)];
    }
    $db->table('tableName')->where($condition)->fetchAll();
    // Expect： select * from tableName
    // Result： select * from tableName where
}
```