### PR TITLE
Repair JOIN Function SQL Statement Splicing Error

### DIFF
--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -155,9 +155,7 @@ class Pdox
         $table = $this->prefix . $table;
 
         if (! is_null($op)) {
-            $on = (! in_array($op, $this->op) ?
-                $this->from . '.' . $field1 . ' = ' . $table . '.' . $op :
-                $this->from . '.' . $field1 . ' ' . $op . ' ' . $table . '.' . $field2);
+            $on = ( !in_array($op, $this->op) ? $field1 . ' = ' . $op : $field1 . ' ' . $op . ' ' . $field2 );
         }
 
         if (is_null($this->join)) {


### PR DESCRIPTION
```php
$db->table('test as t')->join('foo as f', 't.id', 'f.t_id')->where('t.status', 1)->getAll();
# Should Output: "SELECT * FROM test as t JOIN foo as f ON t.id=f.t_id WHERE t.status='1'"
# Actually Output: "SELECT * FROM test as t JOIN foo as f ON test as t.t.id=foo as f.f.t_id WHERE t.status='1'"
```