### PR TITLE
php 7.2 count warning

### DIFF
--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -1187,7 +1187,7 @@ class Pdox
         } else {
             $this->cache = null;
             $this->result = $cache;
-            $this->numRows = count($this->result);
+            $this->numRows = is_countable($this->result) ? count($this->result) : 0;
         }
 
         $this->queryCount++;


### PR DESCRIPTION
php 7.2 count() parameter must be an array or an object that implements countable