### PR TITLE
grouped method: using external data

### DIFF
--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -469,13 +469,14 @@ class Pdox implements PdoxInterface
 
     /**
      * @param Closure $obj
+     * @param $external_data
      *
      * @return $this
      */
-    public function grouped(Closure $obj)
+    public function grouped(Closure $obj, $external_data=null)
     {
         $this->grouped = true;
-        call_user_func_array($obj, [$this]);
+        call_user_func_array($obj, [$this, $external_data]);
         $this->where .= ')';
 
         return $this;

--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -473,10 +473,10 @@ class Pdox implements PdoxInterface
      *
      * @return $this
      */
-    public function grouped(Closure $obj, $external_data=null)
+    public function grouped(Closure $obj, $externalData = null)
     {
         $this->grouped = true;
-        call_user_func_array($obj, [$this, $external_data]);
+        call_user_func_array($obj, [$this, $externalData]);
         $this->where .= ')';
 
         return $this;


### PR DESCRIPTION
The second parameter given to the grouped() method is the correction required for the use of external data.