### PR TITLE
Bug fixed wrong SAVEPOINT name for transactions

### DIFF
--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -969,7 +969,8 @@ class Pdox implements PdoxInterface
      */
     public function transaction()
     {
-        if (!$this->transactionCount++) {
+        if (!$this->transactionCount) {
+            $this->transactionCount++;
             return $this->pdo->beginTransaction();
         }
 
@@ -982,7 +983,7 @@ class Pdox implements PdoxInterface
      */
     public function commit()
     {
-        if (!--$this->transactionCount) {
+        if ($this->transactionCount) {
             return $this->pdo->commit();
         }
 
@@ -994,8 +995,9 @@ class Pdox implements PdoxInterface
      */
     public function rollBack()
     {
-        if (--$this->transactionCount) {
-            $this->pdo->exec('ROLLBACK TO trans' . ($this->transactionCount + 1));
+        if ($this->transactionCount) {
+            $this->pdo->exec('ROLLBACK TO trans' . $this->transactionCount);
+            $this->transactionCount--;
             return true;
         }
 


### PR DESCRIPTION
Merhaba. Dökümandaki `transaction` örneğinde `rollBack` çağırıldığında aşağıdaki hatayı alıyordum.

```
Fatal error: Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT trans0 does not exist in /var/www/html/test/vendor/izniburak/pdox/src/Pdox.php:998 Stack trace: #0 /var/www/html/test/vendor/izniburak/pdox/src/Pdox.php(998): PDO->exec('ROLLBACK TO tra...') #1 /var/www/html/test/transaction.php(47): Buki\Pdox->rollBack() #2 {main} thrown in /var/www/html/test/vendor/izniburak/pdox/src/Pdox.php on line 998
```

Birden fazla `SAVEPOINT` olabilmesi için transaction ile kullanmak istediğimizde `transactionCount` artırılıyor/azaltılıyor. Ancak arttırma ve azaltma bölümlerindeki hata yüzünden oluşurulan `SAVEPOINT`, `rollBack` yapılamıyordu. Bunu çözdüm.