### PR TITLE
Connect options

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -32,7 +32,8 @@ $config = [
 	'password'  => '',
 	'charset'   => 'utf8',
 	'collation' => 'utf8_general_ci',
-	'prefix'    => ''
+	'prefix'    => '',
+  'options'   => [ ]
 ];
 
 $db = new \Buki\Pdox($config);
@@ -84,7 +85,10 @@ $config = [
 
 	# Cache Directory of the Sql Result (optional)
 	# default value: __DIR__ . '/cache/'
-	'cachedir'	=> __DIR__ . '/cache/sql/'
+	'cachedir'	=> __DIR__ . '/cache/sql/',
+
+  # Connection options (Things like SSL certificates, etc)
+  'options' => [ ]
 ];
 
 $db = new \Buki\Pdox($config);
@@ -178,13 +182,13 @@ $db->table(['table1 AS t1', 'table2 AS t2']);
 # get(): return 1 record.
 # getAll(): return multiple records.
 
-$db->table('test')->getAll(); 
+$db->table('test')->getAll();
 # Output: "SELECT * FROM test"
 
 $db->select('username')->table('users')->where('status', 1)->getAll();
 # Output: "SELECT username FROM users WHERE status='1'"
 
-$db->select('title')->table('pages')->where('id', 17)->get(); 
+$db->select('title')->table('pages')->where('id', 17)->get();
 # Output: "SELECT title FROM pages WHERE id='17' LIMIT 1"
 ```
 
@@ -572,19 +576,19 @@ $db->error();
 ### cache
 ```php
 # Usage: ...->cache($time)->...
-$db->table('pages')->where('slug', 'example-page')->cache(60)->get(); 
+$db->table('pages')->where('slug', 'example-page')->cache(60)->get();
 # cache time: 60 seconds
 ```
 
 ### queryCount
 ```php
-$db->queryCount(); 
+$db->queryCount();
 # The number of all SQL queries on the page until the end of the beginning.
 ```
 
 ### getQuery
 ```php
-$db->getQuery(); 
+$db->getQuery();
 # Last SQL Query.
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -33,7 +33,7 @@ $config = [
 	'charset'   => 'utf8',
 	'collation' => 'utf8_general_ci',
 	'prefix'    => '',
-  'options'   => [ ]
+  	'options'   => [ ]
 ];
 
 $db = new \Buki\Pdox($config);
@@ -87,8 +87,8 @@ $config = [
 	# default value: __DIR__ . '/cache/'
 	'cachedir'	=> __DIR__ . '/cache/sql/',
 
-  # Connection options (Things like SSL certificates, etc)
-  'options' => [ ]
+  	# Connection options (Things like SSL certificates, etc)
+  	'options' => [ ]
 ];
 
 $db = new \Buki\Pdox($config);

--- a/src/Pdox.php
+++ b/src/Pdox.php
@@ -108,7 +108,7 @@ class Pdox implements PdoxInterface
         }
 
         try {
-            $this->pdo = new PDO($dsn, $config['username'], $config['password']);
+            $this->pdo = new PDO($dsn, $config['username'], $config['password'], isset($config['options']) ? $config['options'] : null);
             $this->pdo->exec("SET NAMES '" . $config['charset'] . "' COLLATE '" . $config['collation'] . "'");
             $this->pdo->exec("SET CHARACTER SET '" . $config['charset'] . "'");
             $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);


### PR DESCRIPTION
This just extends the PDO connection to allow for situations like below when using tools such as planet scale, who require certain options:

```
$config['options'] = [
  PDO::MYSQL_ATTR_SSL_CA => '/etc/ssl/cert.pem',
  PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
];
```